### PR TITLE
Update about page internal links to extensionless URLs

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,7 +11,7 @@
     <meta property="og:title" content="About Aesthetic Tile - Three Generations of Excellence">
     <meta property="og:description" content="Learn about our family-owned tile business with three generations of craftsmanship serving Central Florida.">
     <meta property="og:image" content="https://www.aesthetictile-florida.com/images/soc-media.png">
-    <meta property="og:url" content="https://www.aesthetictile-florida.com/about.html">
+    <meta property="og:url" content="https://www.aesthetictile-florida.com/about">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Aesthetic Tile">
     <meta property="og:locale" content="en_US">
@@ -23,7 +23,7 @@
     <meta name="twitter:image" content="https://www.aesthetictile-florida.com/images/soc-media.png">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://www.aesthetictile-florida.com/about.html">
+    <link rel="canonical" href="https://www.aesthetictile-florida.com/about">
     
     <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
     <link rel="stylesheet" href="css/style.css">
@@ -125,7 +125,7 @@
         <nav class="main-nav">
             <div class="container">
                 <nav class="navbar">
-                    <a href="index.html" class="logo">
+                    <a href="https://www.aesthetictile-florida.com/" class="logo">
                         <img src="images/aesthetic-tile-logo.png" alt="Aesthetic Tile logo" class="logo-img">
                         <span class="logo-text">Aesthetic Tile</span>
                     </a>
@@ -133,23 +133,23 @@
                     <!-- Desktop Navigation -->
                     <div class="nav-right">
                         <ul class="nav-menu desktop-nav">
-                            <li><a href="index.html">Home</a></li>
-                            <li><a href="about.html">About Us</a></li>
+                            <li><a href="https://www.aesthetictile-florida.com/">Home</a></li>
+                            <li><a href="https://www.aesthetictile-florida.com/about">About Us</a></li>
                             <li class="dropdown">
-                                <a href="services.html" class="dropdown-toggle">Services</a>
+                                <a href="https://www.aesthetictile-florida.com/services" class="dropdown-toggle">Services</a>
                                 <ul class="dropdown-menu">
-                                    <li><a href="kitchen-backsplashes.html">Kitchen Backsplash</a></li>
-                                    <li><a href="bathroom-shower.html">Bathroom &amp; Shower</a></li>
-                                    <li><a href="floor-tile-installation.html">Floor Tile Installation</a></li>
-                                    <li><a href="fireplaces.html">Fireplaces</a></li>
-                                    <li><a href="special-projects.html">Special Projects</a></li>
+                                    <li><a href="https://www.aesthetictile-florida.com/kitchen-backsplashes">Kitchen Backsplash</a></li>
+                                    <li><a href="https://www.aesthetictile-florida.com/bathroom-shower">Bathroom &amp; Shower</a></li>
+                                    <li><a href="https://www.aesthetictile-florida.com/floor-tile-installation">Floor Tile Installation</a></li>
+                                    <li><a href="https://www.aesthetictile-florida.com/fireplaces">Fireplaces</a></li>
+                                    <li><a href="https://www.aesthetictile-florida.com/special-projects">Special Projects</a></li>
                                 </ul>
                             </li>
-                            <li><a href="gallery.html">Gallery</a></li>
-                            <li><a href="contact.html">Contact</a></li>
-                            <li><a href="blog.html">Blog</a></li>
+                            <li><a href="https://www.aesthetictile-florida.com/gallery">Gallery</a></li>
+                            <li><a href="https://www.aesthetictile-florida.com/contact">Contact</a></li>
+                            <li><a href="https://www.aesthetictile-florida.com/blog">Blog</a></li>
                         </ul>
-                        <a href="contact.html" class="cta-button">Request a Quote</a>
+                        <a href="https://www.aesthetictile-florida.com/contact" class="cta-button">Request a Quote</a>
                     </div>
                     
                     <!-- Mobile Menu Button -->
@@ -163,23 +163,23 @@
                 <!-- Mobile Navigation Menu -->
                 <div class="mobile-nav-overlay">
                     <ul class="mobile-nav-menu">
-                        <li><a href="index.html">Home</a></li>
-                        <li><a href="about.html">About Us</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/">Home</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/about">About Us</a></li>
                         <li class="mobile-dropdown">
-                            <a href="services.html" class="mobile-dropdown-toggle">Services</a>
+                            <a href="https://www.aesthetictile-florida.com/services" class="mobile-dropdown-toggle">Services</a>
                             <ul class="mobile-dropdown-menu">
-                                <li><a href="kitchen-backsplashes.html">Kitchen Backsplash</a></li>
-                                <li><a href="bathroom-shower.html">Bathroom &amp; Shower</a></li>
-                                <li><a href="floor-tile-installation.html">Floor Tile Installation</a></li>
-                                <li><a href="fireplaces.html">Fireplaces</a></li>
-                                <li><a href="special-projects.html">Special Projects</a></li>
+                                <li><a href="https://www.aesthetictile-florida.com/kitchen-backsplashes">Kitchen Backsplash</a></li>
+                                <li><a href="https://www.aesthetictile-florida.com/bathroom-shower">Bathroom &amp; Shower</a></li>
+                                <li><a href="https://www.aesthetictile-florida.com/floor-tile-installation">Floor Tile Installation</a></li>
+                                <li><a href="https://www.aesthetictile-florida.com/fireplaces">Fireplaces</a></li>
+                                <li><a href="https://www.aesthetictile-florida.com/special-projects">Special Projects</a></li>
                             </ul>
                         </li>
-                        <li><a href="gallery.html">Gallery</a></li>
-                        <li><a href="contact.html">Contact</a></li>
-                        <li><a href="blog.html">Blog</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/gallery">Gallery</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/contact">Contact</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/blog">Blog</a></li>
                         <li class="mobile-cta">
-                            <a href="contact.html" class="mobile-cta-button">Request a Quote</a>
+                            <a href="https://www.aesthetictile-florida.com/contact" class="mobile-cta-button">Request a Quote</a>
                         </li>
                     </ul>
                 </div>
@@ -336,11 +336,11 @@
                 <div class="footer-section">
                     <h3>Services</h3>
                     <ul>
-                        <li><a href="kitchen-backsplashes.html">Kitchen Backsplash</a></li>
-                        <li><a href="bathroom-shower.html">Bathroom & Shower</a></li>
-                        <li><a href="floor-tile-installation.html">Floor Tile Installation</a></li>
-                        <li><a href="fireplaces.html">Fireplaces</a></li>
-                        <li><a href="special-projects.html">Special Projects</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/kitchen-backsplashes">Kitchen Backsplash</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/bathroom-shower">Bathroom & Shower</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/floor-tile-installation">Floor Tile Installation</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/fireplaces">Fireplaces</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com/special-projects">Special Projects</a></li>
                     </ul>
                 </div>
 


### PR DESCRIPTION
## Summary
- update canonical and Open Graph URLs on the about page to remove the .html suffix
- switch all navigation, CTA, and footer links on about.html to extensionless internal paths
- convert all about page internal navigation links to absolute aesthetictile-florida.com URLs for indexing consistency

## Testing
- not run (static HTML change only)

------
https://chatgpt.com/codex/tasks/task_e_68ce154107a4832eb67e1d48b0f7a139