### PR TITLE
Standardize About page navigation and footer URLs

### DIFF
--- a/about.html
+++ b/about.html
@@ -25,8 +25,8 @@
     <!-- Canonical URL -->
     <link rel="canonical" href="https://www.aesthetictile-florida.com/about">
     
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
-    <link rel="stylesheet" href="css/style.css">
+    <link rel="icon" type="image/png" href="https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png">
+    <link rel="stylesheet" href="https://www.aesthetictile-florida.com/css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -125,15 +125,15 @@
         <nav class="main-nav">
             <div class="container">
                 <nav class="navbar">
-                    <a href="https://www.aesthetictile-florida.com/" class="logo">
-                        <img src="images/aesthetic-tile-logo.png" alt="Aesthetic Tile logo" class="logo-img">
+                    <a href="https://www.aesthetictile-florida.com" class="logo">
+                        <img src="https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png" alt="Aesthetic Tile logo" class="logo-img">
                         <span class="logo-text">Aesthetic Tile</span>
                     </a>
                     
                     <!-- Desktop Navigation -->
                     <div class="nav-right">
                         <ul class="nav-menu desktop-nav">
-                            <li><a href="https://www.aesthetictile-florida.com/">Home</a></li>
+                            <li><a href="https://www.aesthetictile-florida.com">Home</a></li>
                             <li><a href="https://www.aesthetictile-florida.com/about">About Us</a></li>
                             <li class="dropdown">
                                 <a href="https://www.aesthetictile-florida.com/services" class="dropdown-toggle">Services</a>
@@ -163,7 +163,7 @@
                 <!-- Mobile Navigation Menu -->
                 <div class="mobile-nav-overlay">
                     <ul class="mobile-nav-menu">
-                        <li><a href="https://www.aesthetictile-florida.com/">Home</a></li>
+                        <li><a href="https://www.aesthetictile-florida.com">Home</a></li>
                         <li><a href="https://www.aesthetictile-florida.com/about">About Us</a></li>
                         <li class="mobile-dropdown">
                             <a href="https://www.aesthetictile-florida.com/services" class="mobile-dropdown-toggle">Services</a>
@@ -191,7 +191,7 @@
         <!-- About Us Hero Section -->
         <section class="hero" style="min-height: 62vh;">
             <div class="hero-bg">
-                <img src="images/AboutUs-NoText.png" alt="About Us - Aesthetic Tile Kitchen with Hexagonal Backsplash" class="hero-image">
+                <img src="https://www.aesthetictile-florida.com/images/AboutUs-NoText.png" alt="About Us - Aesthetic Tile Kitchen with Hexagonal Backsplash" class="hero-image">
                 <div class="hero-overlay"></div>
             </div>
             <div class="container">
@@ -216,7 +216,7 @@
                             <p>What started as a family trade has grown into a Florida based tile company trusted by homeowners, designers, and builders. Over three generations, we've honed the details that matter: straight lines, tight grout joints, true surfaces, and meticulous prep. That standard is why clients consistently describe our work as "perfectionist," "detail oriented," and "the very best."</p>
                         </div>
                         <div class="story-image">
-                            <img src="images/Brad.webp" alt="Brad from Aesthetic Tile - Professional Tile Installer" class="brad-image">
+                            <img src="https://www.aesthetictile-florida.com/images/Brad.webp" alt="Brad from Aesthetic Tile - Professional Tile Installer" class="brad-image">
                         </div>
                     </div>
                 </div>
@@ -266,7 +266,7 @@
         <!-- CTA Section -->
         <section id="contact" class="cta-section">
             <div class="cta-bg">
-                <img src="images/contact-bg.webp" alt="Beautiful dark wood kitchen with tile backsplash" class="cta-bg-image">
+                <img src="https://www.aesthetictile-florida.com/images/contact-bg.webp" alt="Beautiful dark wood kitchen with tile backsplash" class="cta-bg-image">
                 <div class="cta-overlay"></div>
             </div>
             <div class="container">
@@ -327,7 +327,7 @@
             <div class="footer-content">
                 <div class="footer-section">
                     <div class="footer-logo">
-                        <img src="images/aesthetic-tile-logo.png" alt="Aesthetic Tile logo" class="footer-logo-img">
+                        <img src="https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png" alt="Aesthetic Tile logo" class="footer-logo-img">
                         <span class="footer-logo-text">Aesthetic Tile</span>
                     </div>
                     <p>Professional tile installation services in Central Florida. Expert craftsmanship for kitchens, bathrooms, and specialty projects.</p>


### PR DESCRIPTION
## Summary
- point the About page logo and Home navigation links to the canonical domain without a trailing slash
- update header, hero, CTA, and footer imagery to use absolute site URLs for consistent SEO-friendly references

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce223b5a78832ebc00dd5d1f8373c0