### PR TITLE
Add comprehensive favicon links to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,17 @@
     
     <!-- Canonical URL -->
     <link rel="canonical" href="https://www.aesthetictile-florida.com">
-    
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+
+    <link rel="apple-touch-icon" sizes="180x180" href="images/img/favicon-180x180.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="images/img/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="48x48" href="images/img/favicon-48x48.png">
+    <link rel="icon" type="image/png" sizes="64x64" href="images/img/favicon-64x64.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="images/img/favicon-96x96.png">
+    <link rel="icon" type="image/png" sizes="128x128" href="images/img/favicon-128x128.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="images/img/favicon-512x512.png">
+    <link rel="shortcut icon" href="images/img/favicon-32x32.png">
     <link rel="stylesheet" href="css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- replace the single favicon link on the homepage with links for all available favicon sizes, including the apple touch icon

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0e74dacc8832e8609e71eac1d23ae