### PR TITLE
Fix mobile navigation overlay behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1496,13 +1496,8 @@ body {
         display: flex;
     }
     
-    /* Hide desktop navigation container */
+    /* Mobile navigation overlay */
     .nav-right {
-        display: none;
-    }
-    
-    /* Show mobile navigation */
-    .nav-menu {
         position: fixed;
         top: 0;
         left: -100%;
@@ -1512,30 +1507,42 @@ body {
         flex-direction: column;
         justify-content: flex-start;
         align-items: center;
-        padding-top: 80px;
+        padding: 100px 2rem 2rem;
         gap: 2rem;
         transition: left 0.3s ease;
         z-index: 1000;
         box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
+        overflow-y: auto;
     }
-    
-    /* Show mobile menu when active */
-    .nav-menu.active {
+
+    .nav-right.active {
         left: 0;
-        display: flex;
     }
-    
+
+    .nav-menu {
+        flex-direction: column;
+        align-items: center;
+        gap: 1.5rem;
+        width: 100%;
+    }
+
     .nav-menu li {
         width: 100%;
         text-align: center;
     }
-    
+
     .nav-menu a {
         display: block;
         padding: 1rem 2rem;
         font-size: 1.1rem;
         width: 100%;
         border-bottom: 1px solid #f0f0f0;
+    }
+
+    .cta-button {
+        width: 100%;
+        max-width: 320px;
+        text-align: center;
     }
     
     /* Compact header for mobile */

--- a/js/script.js
+++ b/js/script.js
@@ -40,18 +40,21 @@ document.addEventListener('DOMContentLoaded', function() {
     // Mobile menu functionality
     const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
     const navMenu = document.querySelector('.nav-menu');
-    
-    if (mobileMenuBtn && navMenu) {
+    const navRight = document.querySelector('.nav-right');
+
+    if (mobileMenuBtn && navMenu && navRight) {
         mobileMenuBtn.addEventListener('click', function() {
             mobileMenuBtn.classList.toggle('active');
             navMenu.classList.toggle('active');
+            navRight.classList.toggle('active');
         });
 
         // Close mobile menu when clicking outside
         document.addEventListener('click', function(e) {
-            if (!mobileMenuBtn.contains(e.target) && !navMenu.contains(e.target)) {
+            if (!mobileMenuBtn.contains(e.target) && !navRight.contains(e.target)) {
                 mobileMenuBtn.classList.remove('active');
                 navMenu.classList.remove('active');
+                navRight.classList.remove('active');
             }
         });
 
@@ -60,8 +63,18 @@ document.addEventListener('DOMContentLoaded', function() {
             link.addEventListener('click', function() {
                 mobileMenuBtn.classList.remove('active');
                 navMenu.classList.remove('active');
+                navRight.classList.remove('active');
             });
         });
+
+        const navCta = navRight.querySelector('.cta-button');
+        if (navCta) {
+            navCta.addEventListener('click', function() {
+                mobileMenuBtn.classList.remove('active');
+                navMenu.classList.remove('active');
+                navRight.classList.remove('active');
+            });
+        }
     }
 
     // Service card interactions


### PR DESCRIPTION
## Summary
- convert the mobile navigation to use the `.nav-right` container as a full-screen overlay so the menu and CTA display correctly.
- update the JavaScript toggles to open and close the overlay, including closing when tapping the CTA or outside the menu.

## Testing
- No automated tests were run (static site).


------
https://chatgpt.com/codex/tasks/task_e_68d465980ebc832e9097545d81d19f51