### PR TITLE
Add Vercel redirects for aesthetic tile domains

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "cleanUrls": true,
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [{ "type": "host", "value": "aesthetic-tile-website.vercel.app" }],
+      "destination": "https://www.aesthetictile-florida.com/$1",
+      "permanent": true
+    },
+    {
+      "source": "/(.*)",
+      "has": [{ "type": "host", "value": "aesthetictile-florida.com" }],
+      "destination": "https://www.aesthetictile-florida.com/$1",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add clean URL support and permanent redirects for aesthetic tile domains in Vercel configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6228aeb94832ea4a8fd474b83760e