### PR TITLE
Align gallery and service metadata URLs with clean slugs

### DIFF
--- a/bathroom-shower.html
+++ b/bathroom-shower.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Transform your bathroom with custom tile installation from Aesthetic Tile. We specialize in waterproofed showers, floors, and walls in Groveland, Clermont, and Central FL.">
     <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
     <link rel="stylesheet" href="css/style.css">
+    <meta property="og:url" content="https://www.aesthetictile-florida.com/bathroom-shower">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/bathroom-shower">
     <style>
         /* Specific styles for two-column layout on this page */
@@ -285,7 +286,7 @@
         "@type": "LocalBusiness",
         "name": "Aesthetic Tile",
         "description": "Professional tile installation for kitchens, bathrooms, and flooring in Groveland, FL. Expert craftsmanship for backsplashes, showers, and specialty projects.",
-        "url": "https://www.aesthetictile-florida.com",
+        "url": "https://www.aesthetictile-florida.com/bathroom-shower",
         "telephone": "+1-502-650-7014",
         "email": "office@aesthetictile.com",
         "address": {

--- a/fireplaces.html
+++ b/fireplaces.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Create a stunning focal point with a custom tile fireplace surround from Aesthetic Tile. Serving Groveland, Clermont, and Central Florida with expert craftsmanship.">
     <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
     <link rel="stylesheet" href="css/style.css">
+    <meta property="og:url" content="https://www.aesthetictile-florida.com/fireplaces">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/fireplaces">
     <style>
         /* Specific styles for two-column layout on this page */
@@ -285,7 +286,7 @@
         "@type": "LocalBusiness",
         "name": "Aesthetic Tile",
         "description": "Professional tile installation for kitchens, bathrooms, and flooring in Groveland, FL. Expert craftsmanship for backsplashes, showers, and specialty projects.",
-        "url": "https://www.aesthetictile-florida.com",
+        "url": "https://www.aesthetictile-florida.com/fireplaces",
         "telephone": "+1-502-650-7014",
         "email": "office@aesthetictile.com",
         "address": {

--- a/floor-tile-installation.html
+++ b/floor-tile-installation.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Expert floor tile installation for a durable, beautiful, and timeless look. Aesthetic Tile serves Groveland, Clermont, and Central Florida with master craftsmanship.">
     <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
     <link rel="stylesheet" href="css/style.css">
+    <meta property="og:url" content="https://www.aesthetictile-florida.com/floor-tile-installation">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/floor-tile-installation">
     <style>
         /* Specific styles for two-column layout on this page */
@@ -285,7 +286,7 @@
         "@type": "LocalBusiness",
         "name": "Aesthetic Tile",
         "description": "Professional tile installation for kitchens, bathrooms, and flooring in Groveland, FL. Expert craftsmanship for backsplashes, showers, and specialty projects.",
-        "url": "https://www.aesthetictile-florida.com",
+        "url": "https://www.aesthetictile-florida.com/floor-tile-installation",
         "telephone": "+1-502-650-7014",
         "email": "office@aesthetictile.com",
         "address": {

--- a/gallery.html
+++ b/gallery.html
@@ -7,6 +7,7 @@
     <meta name="description" content="View the project gallery of Aesthetic Tile. See examples of our expert craftsmanship in kitchen backsplashes, bathroom showers, and floor tile installations in Central Florida.">
     <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
     <link rel="stylesheet" href="css/style.css">
+    <meta property="og:url" content="https://www.aesthetictile-florida.com/gallery">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/gallery">
     <style>
         /* Styles for Gallery Page - Add to style.css */
@@ -446,7 +447,7 @@
         "@type": "LocalBusiness",
         "name": "Aesthetic Tile",
         "description": "View the project gallery of Aesthetic Tile. See examples of our expert craftsmanship in kitchen backsplashes, bathroom showers, and floor tile installations in Central Florida.",
-        "url": "https://www.aesthetictile-florida.com",
+        "url": "https://www.aesthetictile-florida.com/gallery",
         "telephone": "+1-502-650-7014",
         "email": "office@aesthetictile.com",
         "address": {

--- a/kitchen-backsplashes.html
+++ b/kitchen-backsplashes.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Elevate your kitchen with a custom tile backsplash from Aesthetic Tile. Expert installation in Groveland, Clermont, and Central Florida for a beautiful, durable finish.">
     <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
     <link rel="stylesheet" href="css/style.css">
+    <meta property="og:url" content="https://www.aesthetictile-florida.com/kitchen-backsplashes">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/kitchen-backsplashes">
     <style>
         /* Specific styles for two-column layout on this page */
@@ -285,7 +286,7 @@
         "@type": "LocalBusiness",
         "name": "Aesthetic Tile",
         "description": "Professional tile installation for kitchens, bathrooms, and flooring in Groveland, FL. Expert craftsmanship for backsplashes, showers, and specialty projects.",
-        "url": "https://www.aesthetictile-florida.com",
+        "url": "https://www.aesthetictile-florida.com/kitchen-backsplashes",
         "telephone": "+1-502-650-7014",
         "email": "office@aesthetictile.com",
         "address": {

--- a/services.html
+++ b/services.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Aesthetic Tile offers expert tile installation services in Central Florida, including custom kitchen backsplashes, bathroom & shower tile, flooring, fireplaces, and special projects.">
     <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
     <link rel="stylesheet" href="css/style.css">
+    <meta property="og:url" content="https://www.aesthetictile-florida.com/services">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/services">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -326,7 +327,7 @@
         "@type": "LocalBusiness",
         "name": "Aesthetic Tile",
         "description": "Explore the custom tile installation services offered by Aesthetic Tile, including bathroom and shower tile, kitchen backsplashes, tile repairs, and demolition services in Central Florida.",
-        "url": "https://www.aesthetictile-florida.com",
+        "url": "https://www.aesthetictile-florida.com/services",
         "telephone": "+1-502-650-7014",
         "email": "office@aesthetictile.com",
         "address": {

--- a/special-projects.html
+++ b/special-projects.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Bring your unique vision to life with custom tile installations for special projects. Aesthetic Tile serves Groveland, Clermont, and Central Florida with creative solutions.">
     <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
     <link rel="stylesheet" href="css/style.css">
+    <meta property="og:url" content="https://www.aesthetictile-florida.com/special-projects">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/special-projects">
     <style>
         /* Specific styles for two-column layout on this page */
@@ -285,7 +286,7 @@
         "@type": "LocalBusiness",
         "name": "Aesthetic Tile",
         "description": "Professional tile installation for kitchens, bathrooms, and flooring in Groveland, FL. Expert craftsmanship for backsplashes, showers, and specialty projects.",
-        "url": "https://www.aesthetictile-florida.com",
+        "url": "https://www.aesthetictile-florida.com/special-projects",
         "telephone": "+1-502-650-7014",
         "email": "office@aesthetictile.com",
         "address": {


### PR DESCRIPTION
## Summary
- add og:url meta tags for the gallery and service pages so they reference the clean URL slugs
- update each page's JSON-LD `url` value to match the clean paths instead of legacy `.html` links

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d623d45c60832ea331a33983d70804