### PR TITLE
Adjust about page intro styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,7 +12,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>
-<body>
+<body class="about-page">
     <!-- Header -->
     <header class="header">
         <!-- Top bar -->

--- a/css/style.css
+++ b/css/style.css
@@ -1659,9 +1659,13 @@ body {
     margin-bottom: 4rem;
 }
 
+.about-page .about-content {
+    padding-top: 3rem;
+}
+
 .about-intro h1 {
     font-size: 2.5rem;
-    color: var(--text-primary);
+    color: var(--accent-color);
     margin-bottom: 1rem;
     font-weight: 700;
 }


### PR DESCRIPTION
## Summary
- update the About page body class so page-specific styles can be targeted
- tint the introductory heading with the site's green accent and add extra spacing below the hero

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d62a925c3c832e8999521eea80ef2c