### PR TITLE
Fix mobile navigation overlay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,6 +28,10 @@ body {
     background-color: var(--white);
 }
 
+body.nav-open {
+    overflow: hidden;
+}
+
 .container {
     max-width: 1200px;
     margin: 0 auto;
@@ -199,7 +203,7 @@ body {
 }
 
 .mobile-menu-btn {
-    display: flex;
+    display: none;
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -1468,21 +1472,13 @@ body {
 
 /* Mobile Hamburger Menu Styles */
 .mobile-menu-btn {
-    display: none;
-    flex-direction: column;
-    justify-content: space-around;
-    width: 30px;
-    height: 30px;
-    background: transparent;
-    border: none;
-    cursor: pointer;
     padding: 0;
     z-index: 1001;
 }
 
 .hamburger-line {
-    width: 100%;
-    height: 3px;
+    width: 1.25rem;
+    height: 2px;
     background-color: var(--accent-color);
     border-radius: 2px;
     transition: all 0.3s ease;
@@ -1508,11 +1504,28 @@ body {
         display: flex;
     }
     
-    /* Hide desktop navigation container */
+    /* Mobile navigation container */
     .nav-right {
+        display: flex;
+        align-items: center;
+        gap: 0;
+    }
+
+    .nav-right .cta-button {
         display: none;
     }
-    
+
+    .nav-menu.active ~ .cta-button {
+        display: inline-flex;
+        position: fixed;
+        bottom: 2rem;
+        left: 50%;
+        transform: translateX(-50%);
+        width: calc(100% - 3rem);
+        justify-content: center;
+        z-index: 1001;
+    }
+
     /* Show mobile navigation */
     .nav-menu {
         position: fixed;
@@ -1525,10 +1538,12 @@ body {
         justify-content: flex-start;
         align-items: center;
         padding-top: 80px;
+        padding-bottom: 6rem;
         gap: 2rem;
         transition: left 0.3s ease;
         z-index: 1000;
         box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
+        overflow-y: auto;
     }
     
     /* Show mobile menu when active */

--- a/js/script.js
+++ b/js/script.js
@@ -42,16 +42,25 @@ document.addEventListener('DOMContentLoaded', function() {
     const navMenu = document.querySelector('.nav-menu');
     
     if (mobileMenuBtn && navMenu) {
+        mobileMenuBtn.setAttribute('aria-expanded', 'false');
+        navMenu.setAttribute('aria-hidden', 'true');
+
         mobileMenuBtn.addEventListener('click', function() {
-            mobileMenuBtn.classList.toggle('active');
-            navMenu.classList.toggle('active');
+            const isOpen = navMenu.classList.toggle('active');
+            mobileMenuBtn.classList.toggle('active', isOpen);
+            mobileMenuBtn.setAttribute('aria-expanded', String(isOpen));
+            navMenu.setAttribute('aria-hidden', String(!isOpen));
+            document.body.classList.toggle('nav-open', isOpen);
         });
 
         // Close mobile menu when clicking outside
         document.addEventListener('click', function(e) {
             if (!mobileMenuBtn.contains(e.target) && !navMenu.contains(e.target)) {
                 mobileMenuBtn.classList.remove('active');
+                mobileMenuBtn.setAttribute('aria-expanded', 'false');
                 navMenu.classList.remove('active');
+                navMenu.setAttribute('aria-hidden', 'true');
+                document.body.classList.remove('nav-open');
             }
         });
 
@@ -59,7 +68,10 @@ document.addEventListener('DOMContentLoaded', function() {
         navMenu.querySelectorAll('a').forEach(link => {
             link.addEventListener('click', function() {
                 mobileMenuBtn.classList.remove('active');
+                mobileMenuBtn.setAttribute('aria-expanded', 'false');
                 navMenu.classList.remove('active');
+                navMenu.setAttribute('aria-hidden', 'true');
+                document.body.classList.remove('nav-open');
             });
         });
     }


### PR DESCRIPTION
## Summary
- ensure the mobile navigation drawer displays instead of being hidden behind the desktop layout
- prevent background scrolling and surface the primary call-to-action when the mobile menu is open
- update the mobile menu script to manage accessibility attributes while toggling the overlay

## Testing
- Manual QA: Viewed the mobile navigation via local HTTP server

------
https://chatgpt.com/codex/tasks/task_e_68d6340ecf08832ebc4fe94e65400d43