### PR TITLE
Add comprehensive favicon assets to all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About Aesthetic Tile - Three Generations of Tile Excellence | Groveland, FL</title>
     <meta name="description" content="Family-owned, Florida-based tile company with a three-generation legacy. We provide custom bathroom and shower tile installation, kitchen backsplashes, tile repairs, and clean demolition/surface prep for Central Florida homes.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/about">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/bathroom-shower.html
+++ b/bathroom-shower.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Custom Bathroom & Shower Tile Installation | Groveland, FL | Aesthetic Tile</title>
     <meta name="description" content="Transform your bathroom with custom tile installation from Aesthetic Tile. We specialize in waterproofed showers, floors, and walls in Groveland, Clermont, and Central FL.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <meta property="og:url" content="https://www.aesthetictile-florida.com/bathroom-shower">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/bathroom-shower">

--- a/blog-marketing-success.html
+++ b/blog-marketing-success.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Investing in Our Future: A Marketing Success Story | Aesthetic Tile Blog</title>
     <meta name="description" content="Discover how Aesthetic Tile's investment in professional marketing and video content is transforming our business and attracting higher-quality projects.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/blog/marketing-success">
     <style>

--- a/blog.html
+++ b/blog.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Aesthetic Tile Blog | Tile Tips & Inspiration | Groveland, FL</title>
     <meta name="description" content="Explore the Aesthetic Tile blog for expert tips on tile installation, design trends for kitchens and bathrooms, and project showcases from Central Florida.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/blog">
     <style>

--- a/browserconfig.xml
+++ b/browserconfig.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<browserconfig>
+  <msapplication>
+    <tile>
+      <square150x150logo src="/images/img/favicon-192x192.png" />
+      <TileColor>#0A4E2C</TileColor>
+    </tile>
+  </msapplication>
+</browserconfig>

--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contact Aesthetic Tile | Free Quote | Groveland, FL</title>
     <meta name="description" content="Contact Aesthetic Tile for a free estimate on your tile installation project. Serving Groveland, Clermont, and Central Florida. Call us or fill out our online form.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/contact">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/fireplaces.html
+++ b/fireplaces.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fireplace Tile Installation | Custom Surrounds | Groveland, FL</title>
     <meta name="description" content="Create a stunning focal point with a custom tile fireplace surround from Aesthetic Tile. Serving Groveland, Clermont, and Central Florida with expert craftsmanship.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <meta property="og:url" content="https://www.aesthetictile-florida.com/fireplaces">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/fireplaces">

--- a/floor-tile-installation.html
+++ b/floor-tile-installation.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Floor Tile Installation | Durable & Stylish | Groveland, FL</title>
     <meta name="description" content="Expert floor tile installation for a durable, beautiful, and timeless look. Aesthetic Tile serves Groveland, Clermont, and Central Florida with master craftsmanship.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <meta property="og:url" content="https://www.aesthetictile-florida.com/floor-tile-installation">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/floor-tile-installation">

--- a/gallery.html
+++ b/gallery.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Project Gallery | Aesthetic Tile | Groveland, FL</title>
     <meta name="description" content="View the project gallery of Aesthetic Tile. See examples of our expert craftsmanship in kitchen backsplashes, bathroom showers, and floor tile installations in Central Florida.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <meta property="og:url" content="https://www.aesthetictile-florida.com/gallery">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/gallery">

--- a/index.html
+++ b/index.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About Aesthetic Tile - Three Generations of Tile Excellence | Groveland, FL</title>
     <meta name="description" content="Family-owned, Florida-based tile company with a three-generation legacy. We provide custom bathroom and shower tile installation, kitchen backsplashes, tile repairs, and clean demolition/surface prep for Central Florida homes.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <link rel="canonical" href="https://www.aesthetictile-florida.com">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/kitchen-backsplashes.html
+++ b/kitchen-backsplashes.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Custom Kitchen Backsplash Tile | Groveland, FL | Aesthetic Tile</title>
     <meta name="description" content="Elevate your kitchen with a custom tile backsplash from Aesthetic Tile. Expert installation in Groveland, Clermont, and Central Florida for a beautiful, durable finish.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <meta property="og:url" content="https://www.aesthetictile-florida.com/kitchen-backsplashes">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/kitchen-backsplashes">

--- a/safari-pinned-tab.svg
+++ b/safari-pinned-tab.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path fill="#000000" d="M30.7 8l-18 48h8.6l4-11h13.4l4 11h8.6l-18-48h-2.6zm1.3 11.6 4.6 13.4H27.4l4.6-13.4z"/>
+</svg>

--- a/services.html
+++ b/services.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Our Tile Services | Custom Installation in Groveland, FL | Aesthetic Tile</title>
     <meta name="description" content="Aesthetic Tile offers expert tile installation services in Central Florida, including custom kitchen backsplashes, bathroom & shower tile, flooring, fireplaces, and special projects.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <meta property="og:url" content="https://www.aesthetictile-florida.com/services">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/services">

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Aesthetic Tile",
+  "short_name": "Aesthetic Tile",
+  "icons": [
+    {
+      "src": "/images/img/favicon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/img/favicon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#0A4E2C",
+  "background_color": "#FFFFFF",
+  "display": "standalone"
+}

--- a/special-projects.html
+++ b/special-projects.html
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Special Projects & Custom Tile Work | Groveland, FL | Aesthetic Tile</title>
     <meta name="description" content="Bring your unique vision to life with custom tile installations for special projects. Aesthetic Tile serves Groveland, Clermont, and Central Florida with creative solutions.">
-    <link rel="icon" type="image/png" href="images/aesthetic-tile-logo.png">
+    <!-- Favicon and app icons -->
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+
+    <!-- High-res icons for Android/Chrome -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
+
+    <!-- Apple iOS/iPadOS -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/img/favicon-180x180.png">
+
+    <!-- Safari pinned tab (macOS) -->
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0A4E2C">
+
+    <!-- Web App manifest -->
+    <link rel="manifest" href="/site.webmanifest">
+
+    <!-- Windows tiles -->
+    <meta name="msapplication-TileColor" content="#0A4E2C">
+    <meta name="msapplication-config" content="/browserconfig.xml">
+
+    <!-- Theme color for address bar / UI -->
+    <meta name="theme-color" content="#0A4E2C">
     <link rel="stylesheet" href="css/style.css">
     <meta property="og:url" content="https://www.aesthetictile-florida.com/special-projects">
     <link rel="canonical" href="https://www.aesthetictile-florida.com/special-projects">


### PR DESCRIPTION
## Summary
- replace the legacy single favicon link on each HTML page with a full favicon/app icon block that references the new image assets
- add supporting PWA/browser metadata files for manifest, Windows tiles, and Safari pinned tabs

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d6af8407f4832e92b5b42d27a151fc