### PR TITLE
Simplify contact page form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -32,9 +32,9 @@
     <link rel="canonical" href="https://www.aesthetictile-florida.com/contact">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=IBM+Plex+Serif:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 </head>
-<body>
+<body class="contact-page">
     <!-- Header -->
     <header class="header">
         <!-- Top bar -->
@@ -151,42 +151,25 @@
                     </div>
                     <div class="cta-form">
                         <form
-                            id="contact-form"
                             action="https://formspree.io/f/mzzjzbpk"
+                            class="fs-form"
+                            target="_top"
                             method="POST"
-                            class="contact-form contact-form--enhanced"
                         >
-                            <div class="contact-form__field">
-                                <label class="contact-form__label" for="contact-name">Name</label>
-                                <input class="contact-form__input" id="contact-name" name="name" type="text" placeholder="Jane Doe" autocomplete="name" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="name">Name</label>
+                                <input class="fs-input" id="name" name="name" />
                             </div>
-
-                            <div class="contact-form__field">
-                                <label class="contact-form__label" for="contact-email">Email</label>
-                                <input class="contact-form__input" id="contact-email" name="email" type="email" placeholder="you@example.com" autocomplete="email" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="email">Email</label>
+                                <input class="fs-input" id="email" name="email" required />
                             </div>
-
-                            <div class="contact-form__field contact-form__field--full">
-                                <label class="contact-form__label" for="contact-message">Message</label>
-                                <textarea class="contact-form__textarea" id="contact-message" name="message" placeholder="Tell us about your project..." rows="5"></textarea>
-                                <p class="contact-form__description">We usually respond within 1–2 business days.</p>
+                            <div class="fs-field">
+                                <label class="fs-label" for="message">Message</label>
+                                <textarea class="fs-textarea" id="message" name="message"></textarea>
                             </div>
-
-                            <div class="contact-form__field">
-                                <label class="contact-form__label" for="contact-phone">Phone <span class="contact-form__optional">(optional)</span></label>
-                                <input class="contact-form__input" id="contact-phone" name="phone" type="tel" placeholder="(555) 555-5555" autocomplete="tel">
-                            </div>
-
-                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" class="contact-form__honeypot" aria-hidden="true">
-                            <input type="hidden" name="_subject" value="Aesthetic Tile — New Contact Form Submission">
-
-                            <div class="contact-form__status contact-form__field--full" aria-live="polite">
-                                <p class="contact-form__message contact-form__message--success" data-message="success">Thanks! Your message has been sent.</p>
-                                <p class="contact-form__message contact-form__message--error" data-message="error">Sorry—something went wrong. Please try again or email us directly.</p>
-                            </div>
-
-                            <div class="contact-form__actions contact-form__field--full">
-                                <button class="btn-primary" type="submit">Send Message</button>
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
                         </form>
                     </div>
@@ -284,63 +267,6 @@
             </div>
         </div>
     </footer>
-    <script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const form = document.getElementById('contact-form');
-        if (!form) return;
-
-        const submitButton = form.querySelector('button[type="submit"]');
-        const successMessage = form.querySelector('[data-message="success"]');
-        const errorMessage = form.querySelector('[data-message="error"]');
-        const messages = [successMessage, errorMessage];
-        const originalButtonText = submitButton ? submitButton.textContent.trim() : '';
-
-        const setLoadingState = (isLoading) => {
-            if (!submitButton) return;
-            submitButton.disabled = isLoading;
-            submitButton.classList.toggle('is-loading', isLoading);
-            submitButton.setAttribute('aria-busy', String(isLoading));
-            submitButton.textContent = isLoading ? 'Sending…' : originalButtonText;
-        };
-
-        const toggleMessage = (type = null) => {
-            messages.forEach((message) => {
-                if (!message) return;
-                const shouldShow = Boolean(type && message.dataset.message === type);
-                message.classList.toggle('is-visible', shouldShow);
-                message.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
-            });
-        };
-
-        toggleMessage();
-
-        form.addEventListener('submit', async (event) => {
-            event.preventDefault();
-
-            toggleMessage();
-            setLoadingState(true);
-
-            try {
-                const response = await fetch(form.action, {
-                    method: 'POST',
-                    body: new FormData(form),
-                    headers: { Accept: 'application/json' }
-                });
-
-                if (response.ok) {
-                    form.reset();
-                    toggleMessage('success');
-                } else {
-                    toggleMessage('error');
-                }
-            } catch (error) {
-                toggleMessage('error');
-            } finally {
-                setLoadingState(false);
-            }
-        });
-    });
-    </script>
     <script src="js/script.js"></script>
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">

--- a/css/style.css
+++ b/css/style.css
@@ -665,6 +665,115 @@ body.nav-open {
     box-shadow: var(--shadow-lg);
 }
 
+/* Simple contact form styles */
+.contact-page {
+    --fs-color-background: #cbd5e1;
+    --fs-color-background-alt: #64748b;
+    --fs-color-border-active: #64748b;
+    --fs-color-border-default: #94a3b8;
+    --fs-color-highlight: #cbd5e1;
+    --fs-color-primary: #1e293b;
+    --fs-color-primary-active: #090f1d;
+    --fs-color-text-default: #0f172a;
+    --fs-color-text-muted: #475569;
+    --fs-font-family-body: "Work Sans", system-ui, sans-serif;
+    --fs-font-family-display: "IBM Plex Serif", system-ui, sans-serif;
+}
+
+.contact-page .fs-form {
+    display: grid;
+    row-gap: 1.5rem;
+    font-family: var(--fs-font-family-body);
+}
+
+.contact-page .fs-field {
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.375rem;
+}
+
+.contact-page .fs-label {
+    color: var(--fs-color-text-default);
+    display: block;
+    font-family: var(--fs-font-family-display);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25rem;
+}
+
+.contact-page .fs-description {
+    color: var(--fs-color-text-muted);
+    display: block;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+}
+
+.contact-page .fs-button-group {
+    display: flex;
+    flex-direction: row-reverse;
+    column-gap: 1.5rem;
+}
+
+.contact-page .fs-button {
+    background-color: var(--fs-color-primary);
+    border-radius: 0.375rem;
+    color: #fff;
+    cursor: pointer;
+    font-family: var(--fs-font-family-display);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1rem;
+    padding: 1rem 2rem;
+    transition-duration: 200ms;
+    transition-property: background-color;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.contact-page .fs-button:hover,
+.contact-page .fs-button:focus-visible {
+    background-color: var(--fs-color-primary-active);
+}
+
+.contact-page .fs-button:focus-visible {
+    outline: 3px solid var(--fs-color-highlight);
+}
+
+.contact-page .fs-input,
+.contact-page .fs-textarea {
+    appearance: none;
+    border-radius: 0.375rem;
+    border-width: 0;
+    box-shadow: var(--fs-color-border-default) 0 0 0 1px inset;
+    color: var(--fs-color-text-default);
+    font-family: var(--fs-font-family-body);
+    font-size: 1rem;
+    line-height: 1.5rem;
+    outline: none;
+    padding: 0.5rem 0.75rem;
+}
+
+.contact-page .fs-input {
+    height: 2.5rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+}
+
+.contact-page .fs-input:focus-visible,
+.contact-page .fs-textarea:focus-visible {
+    box-shadow: var(--fs-color-border-active) 0 0 0 1.5px inset;
+    outline: 3px solid var(--fs-color-highlight);
+    outline-offset: 0;
+}
+
+.contact-page .fs-input::placeholder,
+.contact-page .fs-textarea::placeholder {
+    color: var(--fs-color-text-muted);
+}
+
+.contact-page .fs-textarea {
+    resize: vertical;
+}
+
 .contact-form {
     display: grid;
     gap: 1rem;


### PR DESCRIPTION
## Summary
- replace the contact page form with the simplified Formspree markup
- scope new form styles to the contact page and load the supporting fonts
- remove the custom JavaScript handler tied to the previous enhanced form
- remove the response time note beneath the message field per the updated request

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d6efe6da60832ead1e25108911df9d