### PR TITLE
Update CTA sections to use Formspree inline success handling

### DIFF
--- a/about.html
+++ b/about.html
@@ -215,30 +215,41 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash">Kitchen Backsplash</option>
-                                    <option value="bathroom-shower">Bathroom & Shower</option>
-                                    <option value="floor-tile">Floor Tile Installation</option>
-                                    <option value="fireplace">Fireplace</option>
-                                    <option value="special-project">Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject (optional but recommended) -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -313,7 +324,8 @@
             </div>
         </div>
     </footer>
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
+    <script src="/js/formspree-inline.js" defer></script>
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">
     {

--- a/css/style.css
+++ b/css/style.css
@@ -665,6 +665,91 @@ body.nav-open {
     box-shadow: var(--shadow-lg);
 }
 
+.fs-form {
+    display: grid;
+    row-gap: 1.5rem;
+}
+
+.fs-field {
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.5rem;
+}
+
+.fs-label {
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.fs-input,
+.fs-textarea {
+    width: 100%;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    font-family: inherit;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fs-input:focus,
+.fs-textarea:focus {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px rgba(14, 124, 134, 0.15);
+    outline: none;
+}
+
+.fs-textarea {
+    min-height: 150px;
+    resize: vertical;
+}
+
+.fs-button-group {
+    display: flex;
+    justify-content: flex-start;
+}
+
+.fs-button {
+    background-color: var(--accent-color);
+    border: none;
+    border-radius: 999px;
+    color: var(--white);
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    padding: 0.75rem 2.5rem;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.fs-button:hover,
+.fs-button:focus-visible {
+    background-color: var(--accent-hover);
+}
+
+.fs-button:focus-visible {
+    outline: 3px solid rgba(14, 124, 134, 0.35);
+    outline-offset: 2px;
+}
+
+.fs-button:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.fs-message {
+    font-size: 0.95rem;
+    margin-top: 0.25rem;
+}
+
+.fs-success {
+    color: #047857;
+}
+
+.fs-error {
+    color: #b91c1c;
+}
+
 /* Simple contact form styles */
 .contact-page {
     --fs-color-background: #cbd5e1;

--- a/index.html
+++ b/index.html
@@ -336,30 +336,41 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash">Kitchen Backsplash</option>
-                                    <option value="bathroom-shower">Bathroom & Shower</option>
-                                    <option value="floor-tile">Floor Tile Installation</option>
-                                    <option value="fireplace">Fireplace</option>
-                                    <option value="special-project">Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject (optional but recommended) -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -442,6 +453,7 @@
         </div>
     </footer>
 
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
+    <script src="/js/formspree-inline.js" defer></script>
 </body>
 </html>

--- a/js/formspree-inline.js
+++ b/js/formspree-inline.js
@@ -1,0 +1,41 @@
+// js/formspree-inline.js — attaches inline success handler to any form with [data-inline-success]
+(function () {
+  function bindInlineSuccess(form) {
+    if (!form || form.__inlineBound) return; // avoid double binding
+    form.__inlineBound = true;
+
+    const successEl = form.querySelector('.fs-success');
+    const errorEl = form.querySelector('.fs-error');
+    const submitBtn = form.querySelector('button[type="submit"]');
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (successEl) successEl.style.display = 'none';
+      if (errorEl) errorEl.style.display = 'none';
+      if (submitBtn) submitBtn.disabled = true;
+
+      try {
+        const res = await fetch(form.action, {
+          method: 'POST',
+          body: new FormData(form),
+          headers: { 'Accept': 'application/json' }
+        });
+        if (res.ok) {
+          form.reset();
+          if (successEl) successEl.style.display = 'block';
+        } else {
+          if (errorEl) errorEl.style.display = 'block';
+        }
+      } catch (_) {
+        if (errorEl) errorEl.style.display = 'block';
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
+      }
+    });
+  }
+
+  // Initial bind on DOMContentLoaded
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('form[data-inline-success]').forEach(bindInlineSuccess);
+  });
+})();

--- a/services.html
+++ b/services.html
@@ -250,30 +250,41 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash">Kitchen Backsplash</option>
-                                    <option value="bathroom-shower">Bathroom & Shower</option>
-                                    <option value="floor-tile">Floor Tile Installation</option>
-                                    <option value="fireplace">Fireplace</option>
-                                    <option value="special-project">Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject (optional but recommended) -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -341,7 +352,8 @@
             </div>
         </div>
     </footer>
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
+    <script src="/js/formspree-inline.js" defer></script>
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">
     {


### PR DESCRIPTION
## Summary
- replace the CTA forms on the home, about, and services pages with the shared Formspree inline-success markup
- add a reusable inline submission handler script and include it alongside existing scripts
- extend site styles so fs-form elements render consistently outside the contact page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d734cf3de4832e8e1fa1dea17c9220