### PR TITLE
Update CTA forms to use inline Formspree handler

### DIFF
--- a/bathroom-shower.html
+++ b/bathroom-shower.html
@@ -209,30 +209,39 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash">Kitchen Backsplash</option>
-                                    <option value="bathroom-shower" selected>Bathroom & Shower</option>
-                                    <option value="floor-tile">Floor Tile Installation</option>
-                                    <option value="fireplace">Fireplace</option>
-                                    <option value="special-project">Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -300,6 +309,7 @@
             </div>
         </div>
     </footer>
+    <script src="/js/formspree-inline.js" defer></script>
     <script src="js/script.js"></script>
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">

--- a/blog.html
+++ b/blog.html
@@ -292,30 +292,39 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash">Kitchen Backsplash</option>
-                                    <option value="bathroom-shower">Bathroom & Shower</option>
-                                    <option value="floor-tile">Floor Tile Installation</option>
-                                    <option value="fireplace">Fireplace</option>
-                                    <option value="special-project">Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -383,6 +392,7 @@
             </div>
         </div>
     </footer>
+    <script src="/js/formspree-inline.js" defer></script>
     <script src="js/script.js"></script>
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">

--- a/fireplaces.html
+++ b/fireplaces.html
@@ -209,30 +209,39 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash">Kitchen Backsplash</option>
-                                    <option value="bathroom-shower">Bathroom & Shower</option>
-                                    <option value="floor-tile">Floor Tile Installation</option>
-                                    <option value="fireplace" selected>Fireplace</option>
-                                    <option value="special-project">Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -300,6 +309,7 @@
             </div>
         </div>
     </footer>
+    <script src="/js/formspree-inline.js" defer></script>
     <script src="js/script.js"></script>
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">

--- a/floor-tile-installation.html
+++ b/floor-tile-installation.html
@@ -209,30 +209,39 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash">Kitchen Backsplash</option>
-                                    <option value="bathroom-shower">Bathroom & Shower</option>
-                                    <option value="floor-tile" selected>Floor Tile Installation</option>
-                                    <option value="fireplace">Fireplace</option>
-                                    <option value="special-project">Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -300,6 +309,7 @@
             </div>
         </div>
     </footer>
+    <script src="/js/formspree-inline.js" defer></script>
     <script src="js/script.js"></script>
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">

--- a/gallery.html
+++ b/gallery.html
@@ -343,30 +343,39 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash">Kitchen Backsplash</option>
-                                    <option value="bathroom-shower">Bathroom & Shower</option>
-                                    <option value="floor-tile">Floor Tile Installation</option>
-                                    <option value="fireplace">Fireplace</option>
-                                    <option value="special-project">Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -434,6 +443,7 @@
             </div>
         </div>
     </footer>
+    <script src="/js/formspree-inline.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             var modal = document.getElementById("lightboxModal");

--- a/kitchen-backsplashes.html
+++ b/kitchen-backsplashes.html
@@ -209,30 +209,39 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash" selected>Kitchen Backsplash</option>
-                                    <option value="bathroom-shower">Bathroom & Shower</option>
-                                    <option value="floor-tile">Floor Tile Installation</option>
-                                    <option value="fireplace">Fireplace</option>
-                                    <option value="special-project">Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -300,6 +309,7 @@
             </div>
         </div>
     </footer>
+    <script src="/js/formspree-inline.js" defer></script>
     <script src="js/script.js"></script>
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">

--- a/special-projects.html
+++ b/special-projects.html
@@ -209,30 +209,39 @@
                         </div>
                     </div>
                     <div class="cta-form">
-                        <form class="contact-form">
-                            <div class="form-group">
-                                <input type="text" placeholder="Your Name" required>
+                        <form
+                            class="fs-form"
+                            method="POST"
+                            action="https://formspree.io/f/mzzjzbpk"
+                            target="_top"
+                            data-inline-success
+                        >
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-name">Name</label>
+                                <input class="fs-input" id="cta-name" name="name" type="text" autocomplete="name" required />
                             </div>
-                            <div class="form-group">
-                                <input type="email" placeholder="Email Address" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-email">Email</label>
+                                <input class="fs-input" id="cta-email" name="email" type="email" autocomplete="email" required />
                             </div>
-                            <div class="form-group">
-                                <input type="tel" placeholder="Phone Number" required>
+                            <div class="fs-field">
+                                <label class="fs-label" for="cta-message">Message</label>
+                                <textarea class="fs-textarea" id="cta-message" name="message" placeholder="Tell us about your project…"></textarea>
                             </div>
-                            <div class="form-group">
-                                <select required>
-                                    <option value="">Select Service</option>
-                                    <option value="kitchen-backsplash">Kitchen Backsplash</option>
-                                    <option value="bathroom-shower">Bathroom & Shower</option>
-                                    <option value="floor-tile">Floor Tile Installation</option>
-                                    <option value="fireplace">Fireplace</option>
-                                    <option value="special-project" selected>Special Project</option>
-                                </select>
+
+                            <!-- Honeypot + subject -->
+                            <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;opacity:0;" aria-hidden="true" />
+                            <input type="hidden" name="_subject" value="Aesthetic Tile — New CTA Form Submission" />
+
+                            <!-- Inline status messages (scoped to this form) -->
+                            <div class="col-span-full" aria-live="polite">
+                                <p class="fs-message fs-success" style="display:none;">Thanks! Your message has been sent.</p>
+                                <p class="fs-message fs-error" style="display:none;">Sorry—something went wrong. Please try again or email us directly.</p>
                             </div>
-                            <div class="form-group">
-                                <textarea placeholder="Project Details" rows="4"></textarea>
+
+                            <div class="fs-button-group">
+                                <button class="fs-button" type="submit">Send</button>
                             </div>
-                            <button type="submit" class="btn-primary full-width">Get Free Estimate</button>
                         </form>
                     </div>
                 </div>
@@ -300,6 +309,7 @@
             </div>
         </div>
     </footer>
+    <script src="/js/formspree-inline.js" defer></script>
     <script src="js/script.js"></script>
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- replace the right-column CTA form on the kitchen backsplashes, bathroom & shower, floor tile installation, fireplaces, special projects, gallery, and blog pages with the inline-success Formspree markup
- ensure each updated page loads the shared `/js/formspree-inline.js` script so submissions stay on-page with success/error messaging

## Testing
- no automated tests were run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d749a43ecc832ebb7bb3caa7953d95