### PR TITLE
Adjust About page spacing and image placement

### DIFF
--- a/about.html
+++ b/about.html
@@ -130,11 +130,11 @@
         <!-- About Us Content Section -->
         <section class="about-content">
             <div class="container">
-                <div class="about-intro" style="text-align: center;">
+                <section class="about-section about-story" style="text-align: center;">
                     <h2>Our Story: A Legacy of Craftsmanship Moves to Groveland</h2>
                     <p class="intro-text">The foundation of Aesthetic Tile rests on three generations of specialized knowledge. What began as a dedicated family trade has evolved into a professional tile company trusted by discerning homeowners, interior designers, and custom builders who demand superior quality.</p>
-                </div>
-                <div class="about-story">
+                </section>
+                <section class="about-section about-chapter">
                     <div class="story-grid">
                         <div class="story-text">
                             <h2>A New Chapter in the Sunshine State</h2>
@@ -145,8 +145,8 @@
                             <img src="images/Brad.webp" alt="Brad from Aesthetic Tile - Professional Tile Installer" class="brad-image">
                         </div>
                     </div>
-                </div>
-                <div class="about-difference">
+                </section>
+                <section class="about-section about-difference">
                     <h2>The Aesthetic Tile Difference</h2>
                     <ul>
                         <li><strong>Meticulous Preparation:</strong> A lasting installation starts beneath the surface. We ensure every substrate is sound, waterproof, and perfectly prepared.</li>
@@ -154,8 +154,12 @@
                         <li><strong>Lasting Results:</strong> We don’t cut corners, ensuring your investment remains durable and impressive for years to come.</li>
                     </ul>
                     <p>We look forward to serving our new neighbors in Groveland, Clermont, Winter Garden, and beyond, continuing our legacy of excellence, one tile at a time.</p>
-                </div>
-                <div class="about-services">
+                </section>
+                <!-- Secondary About Image — now ABOVE What We Do -->
+                <figure class="about-secondary-image">
+                    <img src="images/tile-installer-2.webp" alt="Tile installer working carefully on a detailed installation" />
+                </figure>
+                <section class="about-section about-what-we-do">
                     <h2>What We Do</h2>
                     <p>We deliver custom tile installation with clean execution and lasting results. Core services include:</p>
                     <ul class="services-list">
@@ -165,11 +169,7 @@
                         <li><strong>Demolition & surface prep:</strong> tidy removal and prep that protect your home and set the stage for a flawless install.</li>
                     </ul>
                     <p>From intricate mosaics to complex, large projects, we approach every job with the same uncompromising attention to detail—because great tile work is never an accident. It's the result of discipline, patience, and craft.</p>
-                </div>
-                <!-- Secondary About Image (below What We Do, above FAQ) -->
-                <figure class="about-secondary-image" style="margin: 2rem 0;">
-                    <img src="images/tile-installer-2.webp" alt="Tile installer working carefully on a detailed installation" style="width:100%;height:auto;border-radius:0.75rem;box-shadow:var(--shadow-lg);" />
-                </figure>
+                </section>
             </div>
         </section>
 

--- a/css/style.css
+++ b/css/style.css
@@ -2463,3 +2463,38 @@ body.nav-open {
 }
 
 /* Trigger deployment */
+
+/* ABOUT PAGE TWEAKS */
+.about-section {
+    margin-top: 2rem;
+}
+
+.about-chapter p + p {
+    margin-top: 1.25rem;
+}
+
+.about-difference ul {
+    list-style: disc inside;
+    margin: 0;
+    padding: 0;
+}
+
+.about-difference ul li {
+    margin-bottom: 0.75rem;
+}
+
+.about-difference + .about-what-we-do {
+    margin-top: 2.5rem;
+}
+
+.about-secondary-image {
+    margin: 2rem 0 2.25rem;
+}
+
+.about-secondary-image img {
+    width: 100%;
+    height: auto;
+    display: block;
+    border-radius: 0.75rem;
+    box-shadow: var(--shadow-lg);
+}


### PR DESCRIPTION
## Summary
- add scoped section classes to About page content to enable precise spacing adjustments
- increase spacing between About page paragraphs, bullet items, and section transitions
- relocate the secondary About image above the What We Do section and style it with page-specific CSS tweaks

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d85fe8d5ec832eb974bdbdb59213d9