### PR TITLE
Update services page SEO content and imagery

### DIFF
--- a/services.html
+++ b/services.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Our Tile Services | Custom Installation in Groveland, FL | Aesthetic Tile</title>
-    <meta name="description" content="Aesthetic Tile offers expert tile installation services in Central Florida, including custom kitchen backsplashes, bathroom & shower tile, flooring, fireplaces, and special projects.">
+    <title>Tile Installation Services: Kitchen, Bath & Flooring | Groveland & Central FL | Aesthetic Tile</title>
+    <meta name="description" content="Explore Aesthetic Tile's professional installation services in Groveland, Clermont, and Orlando. Specializing in custom kitchen backsplashes, bathrooms, flooring, and fireplaces. Quality craftsmanship guaranteed.">
     <!-- Favicon and app icons -->
     <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
@@ -117,13 +117,14 @@
         <!-- Hero Section -->
         <section class="hero" style="min-height: 62vh;">
             <div class="hero-bg">
-                <img src="images/img/hero-backsplash.png" alt="Aesthetic Tile Services - Tiled Backsplash" class="hero-image">
+                <img src="images/img/hero-backsplash.png" alt="Tile installation services kitchen backsplash in Groveland FL" class="hero-image">
                 <div class="hero-overlay"></div>
             </div>
             <div class="container">
                 <div class="hero-content" style="max-width: 48rem; text-align: center; margin: 0 auto;">
-                    <h1>Our Services</h1>
-                    <p>Providing exceptional tile installation and repair services with a focus on quality and craftsmanship.</p>
+                    <h1>Expert Tile Installation Services in Central Florida</h1>
+                    <p>Aesthetic Tile provides comprehensive tile installation services across Central Florida, including Groveland, Clermont, Minneola, Winter Garden, and the greater Orlando area. Our commitment to meticulous preparation and precise execution ensures lasting results for your home.</p>
+                    <p>We understand the demands of Florida homes, from ensuring robust waterproofing against humidity to selecting durable flooring options.</p>
                 </div>
             </div>
         </section>
@@ -136,6 +137,20 @@
                     <p class="intro-tagline" style="color: var(--text-primary); font-size: 1.25rem;">Serving Groveland, Clermont, & Central Florida</p>
                     <p class="intro-text">Aesthetic Tile is your trusted partner for high-quality tile installation. As third-generation craftsmen, we specialize in transforming homes with beautiful, durable tile work. Our core services include custom kitchen backsplashes, complete bathroom and shower renovations, elegant floor tiling, statement fireplaces, and unique special projects. We are committed to meticulous prep work, clean job sites, and flawless finishes that stand the test of time.</p>
                 </div>
+            </div>
+        </section>
+
+        <section class="section installation-standards">
+            <div class="container">
+                <h2>Our Installation Standards</h2>
+                <p>We build for longevity by following industry best practices, including applicable TCNA guidelines. We use high-quality setting materials and prioritize critical steps like substrate preparation and waterproofing (e.g., Schluter® or Wedi® systems when specified) to ensure a durable, beautiful finish.</p>
+            </div>
+        </section>
+
+        <section class="section materials-expertise">
+            <div class="container">
+                <h2>Materials We Work With</h2>
+                <p>We specialize in a wide range of materials, including ceramic, porcelain, natural stone (marble, travertine), glass, and large-format tiles. Our team helps you select the right material for each space, balancing style, performance, and long-term maintenance.</p>
             </div>
         </section>
 
@@ -152,7 +167,7 @@
                             <a href="https://www.aesthetictile-florida.com/kitchen-backsplashes" class="btn-outline">View Kitchen Backsplash Options</a>
                         </div>
                         <div class="expertise-image">
-                            <img src="images/img/kitchen-backsplash.png" alt="Kitchen Backsplash Installation" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
+                            <img src="images/img/kitchen-backsplash.png" alt="Porcelain kitchen backsplash installation in Clermont FL" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
                         </div>
                     </div>
                 </div>
@@ -163,7 +178,7 @@
                 <div class="container">
                     <div class="expertise-content">
                         <div class="expertise-image">
-                            <img src="images/img/bathroom-shower.png" alt="Bathroom and Shower Tile Installation" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
+                            <img src="images/img/bathroom-shower.png" alt="Bathroom tile installation in Groveland FL" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
                         </div>
                         <div class="expertise-text">
                             <h3>Bathroom & Shower Tile</h3>
@@ -184,7 +199,7 @@
                             <a href="https://www.aesthetictile-florida.com/floor-tile-installation" class="btn-outline">See Flooring Installation Services</a>
                         </div>
                         <div class="expertise-image">
-                            <img src="images/img/floor-tile.png" alt="Floor Tile Installation" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
+                            <img src="images/img/floor-tile.png" alt="Large-format flooring tile installation in Minneola FL" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
                         </div>
                     </div>
                 </div>
@@ -195,7 +210,7 @@
                 <div class="container">
                     <div class="expertise-content">
                         <div class="expertise-image">
-                            <img src="images/img/fireplace.png" alt="Fireplace Tile Installation" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
+                            <img src="images/img/fireplace.png" alt="Custom fireplace tile surround installation in Winter Garden FL" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
                         </div>
                         <div class="expertise-text">
                             <h3>Fireplaces</h3>
@@ -216,7 +231,7 @@
                             <a href="https://www.aesthetictile-florida.com/special-projects" class="btn-outline">Discover Special Tile Projects in Central Florida</a>
                         </div>
                         <div class="expertise-image">
-                            <img src="images/img/special-projects.png" alt="Special Projects Tile Installation" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
+                            <img src="images/img/special-projects.png" alt="Custom tile installation projects in Orlando FL" class="expertise-img" style="aspect-ratio: 1 / 1; object-fit: cover;">
                         </div>
                     </div>
                 </div>
@@ -226,7 +241,7 @@
         <!-- CTA Section -->
         <section id="contact" class="cta-section">
             <div class="cta-bg">
-                <img src="images/contact-bg.webp" alt="Beautiful dark wood kitchen with tile backsplash" class="cta-bg-image">
+                <img src="images/contact-bg.webp" alt="Custom kitchen backsplash installation in Clermont FL" class="cta-bg-image">
                 <div class="cta-overlay"></div>
             </div>
             <div class="container">


### PR DESCRIPTION
## Summary
- update the services page head metadata, hero heading, and intro copy to emphasize Central Florida tile installation coverage
- add new installation standards and materials expertise sections and keep descriptive CTA link text for each service
- optimize services imagery with localized alt text while verifying the existing LocalBusiness schema remains consistent

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8700b2970832e83bb9318be7ca1f3