### PR TITLE
Adjust bathroom shower page layout and styling

### DIFF
--- a/bathroom-shower.html
+++ b/bathroom-shower.html
@@ -38,6 +38,7 @@
             grid-template-columns: 1fr 1fr;
             gap: 4rem;
             align-items: center;
+            margin-bottom: 4rem;
         }
 
         .content-image img {
@@ -45,6 +46,10 @@
             height: auto;
             border-radius: 8px;
             box-shadow: var(--shadow-lg);
+        }
+
+        .bath-services p + p {
+            margin-top: 1.75rem;
         }
 
         @media (max-width: 768px) {
@@ -154,6 +159,19 @@
         <!-- Main Content Section -->
         <section class="main-content" style="padding: 5rem 0;">
             <div class="container">
+                <div class="content-grid">
+                    <div class="content-image">
+                        <img src="images/gallery/bathroom-remodel-tile.webp" loading="lazy" alt="Waterproofing membrane system installed before tiling a shower in Groveland, FL.">
+                    </div>
+                    <div class="content-text">
+                        <h2>Transform Your Bathroom into a Sanctuary</h2>
+                        <p>Your bathroom should be a personal retreat, and the right tile is essential for creating that atmosphere. We specialize in transforming bathrooms with beautiful, durable tile work, from elegant floors and walls to stunning, fully-waterproofed walk-in showers.</p>
+                        <p>Our expert craftsmanship ensures every detail is perfect, especially the critical waterproofing needed for wet areas. We combine precision installation with high-quality materials to deliver a luxurious and long-lasting finish that adds significant value and comfort to your home.</p>
+                        <p>We proudly serve homeowners throughout Central Florida, including Groveland, Clermont, Minneola, Winter Garden, and Orlando, bringing our family's tradition of excellence to every project.</p>
+                        <p>Owner-installed oversight means the same trusted professionals who estimate your project will handle the installation. Our team stays current with TCNA updates, continuing education, and manufacturer-led waterproofing workshops so we can recommend the best approach for your budget and lifestyle.</p>
+                        <p>When you hire Aesthetic Tile, you gain access to a collaborative partner who cares about the final look as much as you do. We coordinate with plumbers, glass installers, and designers to make sure your tub-to-shower conversion or spa-inspired retreat is completed on time and to specification.</p>
+                    </div>
+                </div>
                 <section class="section bath-waterproofing">
                     <h2>The Foundation: Leak-Proof Installation</h2>
                     <p>Waterproofing is the most critical step in any shower. We follow applicable TCNA guidelines and specify proven systems such as Schluter® or Wedi® when required. Our process includes substrate preparation, waterproofing membrane installation, and careful detailing at corners and penetrations.</p>
@@ -178,40 +196,36 @@
                         <li>Curbless (zero-entry) showers</li>
                         <li>Linear drains and low-profile pans</li>
                     </ul>
-                    <p>Our design support covers layout, trims (e.g., Schluter profiles or bullnose), <strong>large format tile</strong> handling, and <strong>custom tile design</strong> details.</p>
+                    <p>Our design support covers layout, trims (e.g., Schluter profiles or bullnose), large format tile handling, and custom tile design details.</p>
                     <p>Clients frequently request statement walls with mosaic insets or stone slabs. We help you select materials that balance aesthetics with maintenance needs, and we deliver precise cuts around valves, niches, and lighting for a showroom-quality finish.</p>
                 </section>
                 <section class="section bath-process">
                     <h2>Our Bathroom Installation Process</h2>
                     <ol>
-                        <li><strong>Consultation:</strong> Scope, materials, and scheduling for your <strong>bathroom renovation</strong> or <strong>master bath remodel</strong>.</li>
+                        <li><strong>Consultation:</strong> Scope, materials, and scheduling for your bathroom renovation or master bath remodel.</li>
                         <li><strong>Preparation:</strong> Surface evaluation, protection of adjacent finishes, and dust control.</li>
                         <li><strong>Waterproofing:</strong> Membrane application and inspections; documentation as requested.</li>
                         <li><strong>Tile Setting:</strong> Layout planning to avoid awkward cuts; precise cuts around valves and outlets.</li>
-                        <li><strong>Grouting & Sealing:</strong> <strong>Mold resistant grout</strong> and sealers where appropriate.</li>
+                        <li><strong>Grouting & Sealing:</strong> Mold resistant grout and sealers where appropriate.</li>
                     </ol>
                     <p>Each step is handled by experienced tile setters who understand the demands of Central Florida homes. From waterproofing membrane curing times to the best sealers for natural stone, we make choices that maximize durability and peace of mind.</p>
                 </section>
-                <div class="content-grid">
-                    <div class="content-image">
-                        <img src="images/gallery/bathroom-remodel-tile.webp" loading="lazy" alt="Waterproofing membrane system installed before tiling a shower in Groveland, FL.">
-                    </div>
-                    <div class="content-text">
-                        <h2>Transform Your Bathroom into a Sanctuary</h2>
-                        <p>Your bathroom should be a personal retreat, and the right tile is essential for creating that atmosphere. We specialize in transforming bathrooms with beautiful, durable tile work, from elegant floors and walls to stunning, fully-waterproofed walk-in showers.</p>
-                        <p>Our expert craftsmanship ensures every detail is perfect, especially the critical waterproofing needed for wet areas. We combine precision installation with high-quality materials to deliver a luxurious and long-lasting finish that adds significant value and comfort to your home.</p>
-                        <p>We proudly serve homeowners throughout Central Florida, including Groveland, Clermont, Minneola, Winter Garden, and Orlando, bringing our family's tradition of excellence to every project.</p>
-                        <p>Owner-installed oversight means the same trusted professionals who estimate your project will handle the installation. Our team stays current with TCNA updates, continuing education, and manufacturer-led waterproofing workshops so we can recommend the best approach for your budget and lifestyle.</p>
-                        <p>When you hire Aesthetic Tile, you gain access to a collaborative partner who cares about the final look as much as you do. We coordinate with plumbers, glass installers, and designers to make sure your tub-to-shower conversion or spa-inspired retreat is completed on time and to specification.</p>
-                    </div>
-                </div>
             </div>
         </section>
         <div class="inline-cta">
             <a class="cta-button" href="/contact">Request a Detailed Remodeling Estimate</a>
         </div>
-        <section class="section bath-testimonial">
-            <blockquote>“We trusted Aesthetic Tile with our master bath remodel. The waterproofing process was thorough and gave us total peace of mind. The best contractors in Groveland!” — Danielle P., Groveland, FL</blockquote>
+        <section class="section bath-testimonial home-testimonials">
+            <div class="container">
+                <h2>What Homeowners Are Saying</h2>
+                <div class="testimonials-grid">
+                    <article class="testimonial-card">
+                        <div class="stars" aria-label="5 out of 5 stars">★★★★★</div>
+                        <p class="quote">“We trusted Aesthetic Tile with our master bath remodel. The waterproofing process was thorough and gave us total peace of mind. The best contractors in Groveland!”</p>
+                        <p class="author">— Danielle P., Groveland, FL</p>
+                    </article>
+                </div>
+            </div>
         </section>
         <!-- FAQ Section -->
         <section class="faq-section">


### PR DESCRIPTION
## Summary
- Move the bathroom remodel photo near the top of the page to highlight visuals sooner
- Add paragraph spacing, remove unnecessary bold text, and restyle the testimonial to match the homepage cards

## Testing
- Opened http://127.0.0.1:8000/bathroom-shower.html

------
https://chatgpt.com/codex/tasks/task_e_68d9804a7530832eb1281d7973716ec2