### PR TITLE
Align special projects layout with bathroom template

### DIFF
--- a/special-projects.html
+++ b/special-projects.html
@@ -201,38 +201,38 @@
                         <p>Planning multiple updates? <a href="/kitchen-backsplashes">Explore Kitchen Backsplash Options</a>, <a href="/bathroom-shower">See Bathroom &amp; Shower Installations</a>, <a href="/floor-tile-installation">See Flooring Installation Services</a>, and <a href="/fireplaces">See Custom Fireplace Surrounds</a> to discover how our team can support your entire remodel.</p>
                     </div>
                 </div>
+                <section class="section sp-what">
+                  <h2>What We Build</h2>
+                  <ul>
+                    <li>Custom mosaics and floor medallions</li>
+                    <li>Accent and feature walls</li>
+                    <li>Outdoor patios, porches, and walkways</li>
+                    <li>Entryways, stair risers, fireplaces, and niche details</li>
+                  </ul>
+                </section>
+                <section class="section sp-materials">
+                  <h2>Materials &amp; Design Options</h2>
+                  <p>We work with ceramic, porcelain, natural stone, glass, and large-format panels. Patterns and layouts are planned to suit the space—subway, herringbone, chevron, geometric mosaics, and medallion inlays. We help match materials to performance needs and the overall design intent.</p>
+                  <p>Mockups and samples confirm color variation, grout contrast, and lighting effects before the first tile is placed. By integrating Schluter profiles, heated floor systems, or custom niches, we ensure your installation blends function with a signature look that reflects your property.</p>
+                </section>
+                <section class="section sp-florida">
+                  <h2>Exterior &amp; Florida-Specific Considerations</h2>
+                  <p>For outdoor and specialty applications, we consider drainage, surface preparation, movement joints, slip resistance, and exposure to heat and humidity. Proper setting materials and grout/seal selections help the installation look great and perform season after season.</p>
+                  <p>From screened lanais overlooking Clermont’s lakes to poolside kitchens in Winter Garden, we evaluate substrate conditions, waterproofing requirements, and expansion joints so the tile remains stable despite rapid weather shifts. Our team also recommends cleaning routines that preserve slip resistance and sheen.</p>
+                </section>
+                <section class="section sp-process">
+                  <h2>Our Process</h2>
+                  <ol>
+                    <li>Consultation and design review</li>
+                    <li>Material guidance and layout planning</li>
+                    <li>Surface preparation and installation</li>
+                    <li>Grouting, finishing, and care guidance</li>
+                  </ol>
+                  <p>Each stage is managed by licensed installers who maintain a clean jobsite, provide proactive updates, and deliver the craftsmanship Groveland and Clermont homeowners expect from a family-owned company.</p>
+                </section>
             </div>
         </section>
         <div class="inline-cta"><a class="cta-button" href="/contact">Request a Custom Project Estimate</a></div>
-        <section class="section sp-what">
-          <h2>What We Build</h2>
-          <ul>
-            <li>Custom mosaics and floor medallions</li>
-            <li>Accent and feature walls</li>
-            <li>Outdoor patios, porches, and walkways</li>
-            <li>Entryways, stair risers, fireplaces, and niche details</li>
-          </ul>
-        </section>
-        <section class="section sp-materials">
-          <h2>Materials &amp; Design Options</h2>
-          <p>We work with ceramic, porcelain, natural stone, glass, and large-format panels. Patterns and layouts are planned to suit the space—subway, herringbone, chevron, geometric mosaics, and medallion inlays. We help match materials to performance needs and the overall design intent.</p>
-          <p>Mockups and samples confirm color variation, grout contrast, and lighting effects before the first tile is placed. By integrating Schluter profiles, heated floor systems, or custom niches, we ensure your installation blends function with a signature look that reflects your property.</p>
-        </section>
-        <section class="section sp-florida">
-          <h2>Exterior &amp; Florida-Specific Considerations</h2>
-          <p>For outdoor and specialty applications, we consider drainage, surface preparation, movement joints, slip resistance, and exposure to heat and humidity. Proper setting materials and grout/seal selections help the installation look great and perform season after season.</p>
-          <p>From screened lanais overlooking Clermont’s lakes to poolside kitchens in Winter Garden, we evaluate substrate conditions, waterproofing requirements, and expansion joints so the tile remains stable despite rapid weather shifts. Our team also recommends cleaning routines that preserve slip resistance and sheen.</p>
-        </section>
-        <section class="section sp-process">
-          <h2>Our Process</h2>
-          <ol>
-            <li>Consultation and design review</li>
-            <li>Material guidance and layout planning</li>
-            <li>Surface preparation and installation</li>
-            <li>Grouting, finishing, and care guidance</li>
-          </ol>
-          <p>Each stage is managed by licensed installers who maintain a clean jobsite, provide proactive updates, and deliver the craftsmanship Groveland and Clermont homeowners expect from a family-owned company.</p>
-        </section>
         <!-- FAQ Section -->
         <section class="faq-section">
             <div class="container" style="max-width: 800px; text-align: center;">


### PR DESCRIPTION
## Summary
- nest the special projects supporting sections inside the main content container to match the bathroom template layout
- place the inline call-to-action after the container and fix copy spacing for the materials paragraph

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9b55c1540832ea0b8f93060bd2e9d