### PR TITLE
Remove leftover installation standards block from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,20 +150,6 @@
             </div>
         </section>
 
-        <section class="section installation-standards">
-            <div class="container">
-                <h2>Our Installation Standards</h2>
-                <p>We build for longevity by following industry best practices, including applicable TCNA guidelines. We use high-quality setting materials and prioritize critical steps like substrate preparation and waterproofing (e.g., Schluter® or Wedi® systems when specified) to ensure a durable, beautiful finish.</p>
-            </div>
-        </section>
-
-        <section class="section materials-expertise">
-            <div class="container">
-                <h2>Materials We Work With</h2>
-                <p>We specialize in a wide range of materials, including ceramic, porcelain, natural stone (marble, travertine), glass, and large-format tiles. Our team helps you select the right material for each space, balancing style, performance, and long-term maintenance.</p>
-            </div>
-        </section>
-
     <!-- Video Section -->
     <section class="video-section">
         <div class="container">


### PR DESCRIPTION
## Summary
- remove the outdated installation standards and materials sections from the homepage to clean up duplicated content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae1e8f5e8832ea3f8f878ef79177e