### PR TITLE
Add internal links to marketing success blog post

### DIFF
--- a/blog-marketing-success.html
+++ b/blog-marketing-success.html
@@ -128,7 +128,7 @@
 
                     <h2>Why Marketing Matters for Our Customers</h2>
 
-                    <p>As a professional tile installer, we know that clear communication and thoughtful planning are essential to every project. We're a local tile company serving Central Florida—from Groveland and Clermont to Minneola, Winter Garden, and the greater Orlando area.</p>
+                    <p>As a <a href="/services">professional tile installer</a>, we know that clear communication and thoughtful planning are essential to every project. We're a <a href="/about">local tile company serving Central Florida</a>—from Groveland and Clermont to Minneola, Winter Garden, and the greater Orlando area.</p>
 
                     <p>This renewed focus on storytelling lets homeowners see the care that goes into our custom tile design work, whether we're crafting <a href="/kitchen-backsplashes">kitchen backsplashes</a> or transforming a bathroom and shower retreat. The professional content we captured shows the quality tile work Florida families expect and helps you feel confident choosing us for your next renovation.</p>
 
@@ -175,7 +175,7 @@
 
                     <p>Since implementing our new strategy, we’ve seen better project fit and clearer communication here in the greater Orlando area, including Groveland, Clermont, Minneola, and Winter Garden.</p>
 
-                    <p>This effort helps local homeowners find a tile contractor in Groveland when they’re searching for tile installation in Central Florida. It also makes it easier to explore the tile installation services that keep your home project on schedule.</p>
+                    <p>This effort helps local homeowners find a tile contractor in Groveland when they’re searching for tile installation in Central Florida. It also makes it easier to explore the <a href="/services">tile installation services</a> that keep your home project on schedule.</p>
 
                     <div class="highlight-box">
                         <p><strong>Ready to Start Your Project?</strong> If you're inspired by our commitment to quality and professionalism, we'd love to discuss your next tile project. Contact us today to see how our expertise and passion can transform your space into something truly spectacular.</p>


### PR DESCRIPTION
## Summary
- add internal links in the marketing success blog post that point to the main services and about pages

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc2772f098832eb2fb7b2085e53212