### PR TITLE
Add image sitemap covering all site pages

### DIFF
--- a/image-sitemap.xml
+++ b/image-sitemap.xml
@@ -1,0 +1,364 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>https://www.aesthetictile-florida.com/about</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/AboutUs-NoText.png</image:loc>
+      <image:title>About Us - Aesthetic Tile Kitchen with Hexagonal Backsplash</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Brad.webp</image:loc>
+      <image:title>Brad from Aesthetic Tile - Professional Tile Installer</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/tile-installer-2.webp</image:loc>
+      <image:title>Tile installer working carefully on a detailed installation</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Beautiful dark wood kitchen with tile backsplash</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/bathroom-shower</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile bathroom and shower tile installation company logo in Groveland, FL.</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/AboutUs-NoText.png</image:loc>
+      <image:title>Custom walk-in shower installation with built-in niche in Clermont, FL.</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/bathroom-remodel-tile.webp</image:loc>
+      <image:title>Waterproofing membrane system installed before tiling a shower in Groveland, FL.</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Bathroom and shower tile installation consultation backdrop in Groveland, FL.</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/blog-groveland-grand-opening</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Groveland.webp</image:loc>
+      <image:title>Local tile company team at new Groveland location</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/blog-marketing-success</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Tile-Shop-Feature.png</image:loc>
+      <image:title>Behind-the-scenes video shoot showcasing Aesthetic Tile’s installation process in Central Florida</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Tile-Shop-2.webp</image:loc>
+      <image:title>Aesthetic Tile team filming tile installation services for Central Florida homeowners</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Tile-Shop-3.webp</image:loc>
+      <image:title>Professional lighting setup highlighting quality tile work in Florida homes</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/blog-pre-mixed-grout</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Premixed-grout.webp</image:loc>
+      <image:title>Pre-mixed grout application during backsplash installation in Groveland, FL</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/blog</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Tile-Shop-Feature.png</image:loc>
+      <image:title>Feature display inside the Aesthetic Tile showroom</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Tile-Shop-Photoshoot.webp</image:loc>
+      <image:title>Aesthetic Tile filming Myth Breakers inside The Tile Shop in Orlando</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Premixed-grout.webp</image:loc>
+      <image:title>Installer applying pre mixed grout to a mosaic backsplash</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Groveland.webp</image:loc>
+      <image:title>Aesthetic Tile team celebrating the Groveland location announcement</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Beautiful dark wood kitchen with tile backsplash</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/blog/myth-breakers-episode-1</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Tile-Shop-Photoshoot.webp</image:loc>
+      <image:title>Brad presenting tile selections during a photoshoot at The Tile Shop in Orlando</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/contact</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Contact Aesthetic Tile for a free quote</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/admiring-backsplash.webp</image:loc>
+      <image:title>Client admiring a beautiful and lasting tile backsplash</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/fireplaces</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/AboutUs-NoText.png</image:loc>
+      <image:title>Contemporary tile fireplace feature wall installation in Clermont, FL</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/fireplace-project-square-tile.webp</image:loc>
+      <image:title>Custom porcelain fireplace surround installation in Groveland, FL living room</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Beautiful dark wood kitchen with tile backsplash</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/floor-tile-installation</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile floor tile installation experts in Groveland, FL</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/AboutUs-NoText.png</image:loc>
+      <image:title>Floor tile installation project for a Central Florida home renovation</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/bathroom-floor-tile-checkered.webp</image:loc>
+      <image:title>Checkered porcelain floor tile installation in Clermont, FL</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Floor tile installation enhancing a dark wood kitchen in Orlando, FL</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/gallery</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/AboutUs-NoText.png</image:loc>
+      <image:title>Gallery of beautiful tile projects</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/bathroom-floor-tile-checkered.webp</image:loc>
+      <image:title>Black and white marble checkered bathroom floor tile installation in Groveland, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/bathroom-remodel-stone-tile.webp</image:loc>
+      <image:title>Gray porcelain large-format bathroom shower tile renovation in Clermont, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/bathroom-remodel-tan-tile.webp</image:loc>
+      <image:title>Tan stone-look porcelain bathroom remodel installation in Winter Garden, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/bathroom-remodel-tile.webp</image:loc>
+      <image:title>Polished marble shower wall tile renovation in Minneola, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/bathroom-tile-floor-mosaic.webp</image:loc>
+      <image:title>Colorful mosaic ceramic bathroom floor tile installation in Orlando, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/fireplace-project-square-tile.webp</image:loc>
+      <image:title>Textured ceramic square tile fireplace surround installation in Groveland, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/fireplace-project.webp</image:loc>
+      <image:title>Stacked stone veneer fireplace refacing installation in Clermont, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/fireplace-stone.webp</image:loc>
+      <image:title>Natural stone ledgestone fireplace surround installation in Winter Garden, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/fireplace-tile-stone.webp</image:loc>
+      <image:title>Chevron marble tile fireplace feature installation in Minneola, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/kitchen-backsplash-black-tile.webp</image:loc>
+      <image:title>Matte black ceramic hexagon kitchen backsplash installation in Groveland, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/kitchen-backsplash-star-wars.webp</image:loc>
+      <image:title>Glossy glass mosaic kitchen backsplash installation in Clermont, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/kitchen-backsplash-stone-lock.webp</image:loc>
+      <image:title>Gray stone ledger kitchen backsplash installation in Winter Garden, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/kitchen-backsplash-stone-wedge.webp</image:loc>
+      <image:title>Multitone stone wedge kitchen backsplash installation in Minneola, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/kitchen-backsplash-tile.webp</image:loc>
+      <image:title>Classic white ceramic square tile kitchen backsplash installation in Orlando, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/patio-tile-black.webp</image:loc>
+      <image:title>Charcoal porcelain outdoor patio tile installation in Groveland, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Beautiful dark wood kitchen with tile backsplash</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/hero-backsplash.png</image:loc>
+      <image:title>Completed custom kitchen backsplash tile installation in Groveland FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/Tile-Collage.webp</image:loc>
+      <image:title>Tile flooring installation details in Groveland FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/kitchen-backsplash.png</image:loc>
+      <image:title>Completed custom kitchen backsplash tile installation in Groveland FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/bathroom-shower.png</image:loc>
+      <image:title>Porcelain bathroom shower tile installation in Clermont FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/floor-tile.png</image:loc>
+      <image:title>Large-format flooring tile installation in Minneola FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/fireplace.png</image:loc>
+      <image:title>Custom fireplace tile surround installation in Groveland FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/special-projects.png</image:loc>
+      <image:title>Specialty mosaic tile installation in Winter Garden FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Luxury kitchen tile backsplash installation in Clermont FL by Aesthetic Tile</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/kitchen-backsplashes</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/AboutUs-NoText.png</image:loc>
+      <image:title>White ceramic subway tile backsplash installation in Clermont, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/kitchen-backsplash-stone-lock.webp</image:loc>
+      <image:title>Natural stone mosaic kitchen backsplash installation in Groveland, FL by Aesthetic Tile</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Dark stone mosaic kitchen backsplash installation in Groveland, FL by Aesthetic Tile</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/services</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/hero-backsplash.png</image:loc>
+      <image:title>Tile installation services kitchen backsplash in Groveland FL</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/kitchen-backsplash.png</image:loc>
+      <image:title>Porcelain kitchen backsplash installation in Clermont FL</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/bathroom-shower.png</image:loc>
+      <image:title>Bathroom tile installation in Groveland FL</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/floor-tile.png</image:loc>
+      <image:title>Large-format flooring tile installation in Minneola FL</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/fireplace.png</image:loc>
+      <image:title>Custom fireplace tile surround installation in Winter Garden FL</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/img/special-projects.png</image:loc>
+      <image:title>Custom tile installation projects in Orlando FL</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Custom kitchen backsplash installation in Clermont FL</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.aesthetictile-florida.com/special-projects</loc>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/aesthetic-tile-logo.png</image:loc>
+      <image:title>Aesthetic Tile logo for Central Florida tile installers</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/AboutUs-NoText.png</image:loc>
+      <image:title>Custom tile feature project in Groveland, Florida</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/gallery/fireplace-tile-stone.webp</image:loc>
+      <image:title>Custom fireplace tile installation in Clermont, Florida</image:title>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.aesthetictile-florida.com/images/contact-bg.webp</image:loc>
+      <image:title>Luxury kitchen tile backsplash installation in Orlando, Florida</image:title>
+    </image:image>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- generate a dedicated image sitemap that lists every image currently used across the site’s pages, including blog posts
- capture image titles from existing alt text to improve search engine context

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd36b152bc832ea43c009fd875da54