### PR TITLE
Add Google Search favicon sizes to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,14 @@
     <!-- Favicon and app icons -->
     <link rel="icon" type="image/png" sizes="32x32" href="/images/img/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/images/img/favicon-16x16.png">
+    <link rel="shortcut icon" href="/favicon.ico">
+
+    <!-- Favicons for Google Search -->
+    <link rel="icon" href="/images/img/favicon-48x48.png" sizes="48x48" type="image/png">
+    <link rel="icon" href="/images/img/favicon-96x96.png" sizes="96x96" type="image/png">
+    <link rel="icon" href="/images/img/favicon-192x192.png" sizes="192x192" type="image/png">
 
     <!-- High-res icons for Android/Chrome -->
-    <link rel="icon" type="image/png" sizes="192x192" href="/images/img/favicon-192x192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="/images/img/favicon-512x512.png">
 
     <!-- Apple iOS/iPadOS -->


### PR DESCRIPTION
## Summary
- add Google Search recommended favicon sizes to the home page head
- reference the legacy favicon.ico once to ensure classic browsers still load it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1eaa830fc832ebdd19ded7ce33a1a